### PR TITLE
Re-add coverage report generation to workflow

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run tests using jest
         run: |
           npm ci
-          npx jest
+          npx nyc --reporter=lcov jest
       - name: Codecov
         uses: codecov/codecov-action@v3.1.0
       


### PR DESCRIPTION
@Akashic101, I was doing one final check, and I noticed that you removed the `nyc` coverage report generation from the GitHub workflow. Without that, the code coverage badge won't updated. This PR re-adds the report generation.